### PR TITLE
Fix issue loading spec file + error when not specifying logo

### DIFF
--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -126,7 +126,7 @@ module.exports = function(grunt, options, spec) {
       copy: {
           logo: {
               src: options.logoFile,
-              dest: options.targetDir + '/images/' + path.basename(options.logoFile)
+              dest: options.targetDir + '/images/' + path.basename(options.logoFile || '')
           }
       },
 

--- a/bin/spectacle-cli.js
+++ b/bin/spectacle-cli.js
@@ -47,7 +47,7 @@ program.specFile = program.args[0] || 'test/fixtures/cheese.json';
 //
 //= Load the specification and set variables
 
-var specData = require(path.resolve(program.specFile)),
+var specData = require(path.resolve(process.cwd()+'/'+program.specFile)),
     templateData = require(path.resolve(program.appDir + '/lib/preprocessor'))(program, specData),
     config = require(path.resolve(program.configFile))(grunt, program, templateData);
 

--- a/bin/spectacle-cli.js
+++ b/bin/spectacle-cli.js
@@ -47,7 +47,7 @@ program.specFile = program.args[0] || 'test/fixtures/cheese.json';
 //
 //= Load the specification and set variables
 
-var specData = require(path.resolve(process.cwd()+'/'+program.specFile)),
+var specData = require(path.resolve(cwd+'/'+program.specFile)),
     templateData = require(path.resolve(program.appDir + '/lib/preprocessor'))(program, specData),
     config = require(path.resolve(program.configFile))(grunt, program, templateData);
 


### PR DESCRIPTION
Hey there,

I like spectacle, but it seems there were some issues actually using it:

- Spectacle did not look for the spec file in the current working directory 
- Refused to work when no logo url was specified (crash on path.basename when logoFile is null)

This PR fixes both issues by having Spectacle look for the spec file in `cwd` and defaulting to `''`for logo (which doesn't render nicely in the html, but hey).