### PR TITLE
Comment out reference to "entitites" package as this package is part of the project

### DIFF
--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -1,5 +1,5 @@
 var cheerio = require("cheerio");
-var entities = require("entities");
+// var entities = require("entities");
 var marked = require("marked");
 var highlight = require('highlight.js');
 

--- a/app/views/partials/json-schema/datatype.hbs
+++ b/app/views/partials/json-schema/datatype.hbs
@@ -24,6 +24,8 @@
       {{! Render enums in the descriminator as links to the appropriate definitions}}
       {{#if ../discriminator}}
         <span class="json-property-enum-item"><a href="#definition-{{.}}">{{.}}</a></span>
+      {{else if $ref}}
+          {{~>json-schema/reference .}}
       {{else}}
         <span class="json-property-enum-item">{{.}}</span>
       {{/if}}


### PR DESCRIPTION
It is  not referenced from the package.json (which is causing execution to fail), and not used anywhere.

This line could be deleted instead of commented out, but the reference is commented out it other files, so I followed that pattern to maintain consistency.