### PR TITLE
Fix handlebars spec mutation

### DIFF
--- a/app/helpers/printSchemaReference.js
+++ b/app/helpers/printSchemaReference.js
@@ -10,18 +10,20 @@ module.exports = function(reference, options) {
   var model = common.resolveSchemaReference(reference, options.data.root);
   if (typeof model === 'object' && typeof model.properties === 'object')
     model = model.properties;
-  Object.keys(model).forEach(function(propName) {
-    var prop = model[propName];
+    
+  var clonedModel = JSON.parse(JSON.stringify(model));
+  Object.keys(clonedModel).forEach(function(propName) {
+    var prop = clonedModel[propName];
     if (prop.type) {
-      model[propName] = prop.type;
+        clonedModel[propName] = prop.type;
       if (prop.format) {
-        model[propName] += ('(' + prop.format + ')');
+          clonedModel[propName] += ('(' + prop.format + ')');
       }
     }
   })
   if (options.hash.type == 'array')
-    model = [model];
-  var html = common.printSchema(model);
+      clonedModel = [clonedModel];
+  var html = common.printSchema(clonedModel);
   // html = common.highlight(html, 'json')
   // html = entities.decodeHTML(html); html;
   return new Handlebars.SafeString(html);

--- a/app/helpers/printSchemaReference.js
+++ b/app/helpers/printSchemaReference.js
@@ -2,28 +2,40 @@ var Handlebars = require("handlebars");
 var common = require("../lib/common");
 // var entities = require("entities");
 
+var formatModel = function(model, options) {
+    if (typeof model === 'object' && typeof model.properties === 'object')
+        model = model.properties;
+    
+    var clonedModel = JSON.parse(JSON.stringify(model));
+    Object.keys(clonedModel).forEach(function(propName) {
+        var prop = clonedModel[propName];
+        if (prop.type) {
+            if (prop.type !== "object") {
+                clonedModel[propName] = prop.type;
+            } else {
+                clonedModel[propName] = formatModel(prop, options)
+            }
+        }
+            
+        if (prop.format) {
+            clonedModel[propName] += ('(' + prop.format + ')');
+        }
+    })
+    
+    if (options.hash.type == 'array')
+        clonedModel = [clonedModel];
+    
+    return clonedModel;
+}
+
 module.exports = function(reference, options) {
   if (!reference) {
     console.error("Cannot print null reference.");
     return '';
   }
   var model = common.resolveSchemaReference(reference, options.data.root);
-  if (typeof model === 'object' && typeof model.properties === 'object')
-    model = model.properties;
-    
-  var clonedModel = JSON.parse(JSON.stringify(model));
-  Object.keys(clonedModel).forEach(function(propName) {
-    var prop = clonedModel[propName];
-    if (prop.type) {
-        clonedModel[propName] = prop.type;
-      if (prop.format) {
-          clonedModel[propName] += ('(' + prop.format + ')');
-      }
-    }
-  })
-  if (options.hash.type == 'array')
-      clonedModel = [clonedModel];
-  var html = common.printSchema(clonedModel);
+    model = formatModel(model, options);
+  var html = common.printSchema(model);
   // html = common.highlight(html, 'json')
   // html = entities.decodeHTML(html); html;
   return new Handlebars.SafeString(html);


### PR DESCRIPTION
printSchemaReference was mutating the underling definitions objects, which caused usage of those objects in subsequent handlebars templates to mis-behave.
Cloning the object before modifying the values seems to fix the issue for me.