### PR TITLE
Updated grunt-sass to 2.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-contrib-copy": "^0.8.2",
     "grunt-prettify": "^0.4.0",
-    "grunt-sass": "^1.2.1",
+    "grunt-sass": "^2.0.0",
     "handlebars": "^4.0.5",
     "highlight.js": "^9.1.0",
     "json-stable-stringify": "^1.0.1",


### PR DESCRIPTION
Includes fix for sass/node-sass#1589, which improves building node-sass on Alpine Linux.

I've very quickly tested this by publishing `@codelenny/spectacle-docs@0.1.1`, which ran with no issues that I could see.