### PR TITLE
Forced HTTPS for JQuery reference

### DIFF
--- a/app/views/partials/layout/head.hbs
+++ b/app/views/partials/layout/head.hbs
@@ -6,6 +6,6 @@
 <title>{{info.title}} | API Reference</title>
 <link rel="stylesheet" href="stylesheets/foundation.min.css" />
 <link rel="stylesheet" href="stylesheets/spectacle.min.css" />
-<script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
+<script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
 <!-- <script src="javascripts/foundation.js"></script> -->
 <script src="javascripts/spectacle.min.js"></script>


### PR DESCRIPTION
This will allow the reference to work when "opening" the HTML file locally, assuming the computer has internet access of course