### PR TITLE
Generate Temporary Directories

### DIFF
--- a/bin/spectacle.js
+++ b/bin/spectacle.js
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 
 var program = require('commander'),
+    tmp = require('tmp'),
     fs = require('fs'),
     os = require('os'),
     path = require('path'),
     package = require('../package'),
     spectacle = require('../index.js');
+
+// Ensures temporary files are cleaned up on program close, even if errors are encountered.
+tmp.setGracefulCleanup();
 
 var cwd = process.cwd(),
     root = path.resolve(__dirname, '..');
@@ -35,8 +39,8 @@ if (program.args.length < 1) { // && program.rawArgs.length < 1
     program.help();
 }
 
-// Set some necessary defaults
-program.cacheDir = os.tmpdir() + '/.spectacle';
+// Create a new temporary directory, and set some necessary defaults
+program.cacheDir = tmp.dirSync({ unsafeCleanup: true, prefix: 'spectacle-' });
 program.specFile = program.args[0]; // || path.resolve(root, 'test/fixtures/cheese.json');
 
 // Replace some absolute paths

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "grunt-contrib-handlebars": "^0.11.0",
     "grunt-contrib-uglify": "^0.11.0",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-contrib-copy": "^0.8.2",
     "grunt-prettify": "^0.4.0",
     "grunt-sass": "^2.0.0",
     "handlebars": "^4.0.5",
@@ -52,6 +51,7 @@
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.2.1",
     "marked": "^0.3.5",
+    "tmp": "0.0.31",
     "trace": "^1.1.0"
   }
 }


### PR DESCRIPTION
Uses unique cache directories, instead of reusing the same one.  This resolves issues encountered when compiling multiple files simultaneously.

Closes #30.