### PR TITLE
Update to be more compatible with programmatic usage

### DIFF
--- a/bin/spectacle.js
+++ b/bin/spectacle.js
@@ -1,18 +1,10 @@
 #!/usr/bin/env node
 
 var program = require('commander'),
-    tmp = require('tmp'),
-    fs = require('fs'),
-    os = require('os'),
-    path = require('path'),
     package = require('../package'),
     spectacle = require('../index.js');
 
-// Ensures temporary files are cleaned up on program close, even if errors are encountered.
-tmp.setGracefulCleanup();
 
-var cwd = process.cwd(),
-    root = path.resolve(__dirname, '..');
 
 //
 //= Process CLI input
@@ -25,12 +17,12 @@ program.version(package.version)
     .option('-e, --embeddable', 'omit the HTML <body/> and generate the documentation content only (default: false)')
     .option('-d, --development-mode', 'start HTTP server with the file watcher and live reload (default: false)')
     .option('-s, --start-server', 'start the HTTP server without any development features')
-    .option('-p, --port <dir>', 'the port number for the HTTP server to listen on (default: 4400)', Number, 4400)
-    .option('-t, --target-dir <dir>', 'the target build directory (default: public)', String, path.resolve(cwd, 'public'))
-    .option('-f, --target-file <file>', 'the target build HTML file (default: index.html)', String, 'index.html')
-    .option('-a, --app-dir <dir>', 'the application source directory (default: app)', String, path.resolve(root, 'app'))
+    .option('-p, --port <dir>', 'the port number for the HTTP server to listen on (default: 4400)', Number)
+    .option('-t, --target-dir <dir>', 'the target build directory (default: public)', String)
+    .option('-f, --target-file <file>', 'the target build HTML file (default: index.html)', String)
+    .option('-a, --app-dir <dir>', 'the application source directory (default: app)', String)
     .option('-l, --logo-file <file>', 'specify a custom logo file (default: null)', String, null)
-    .option('-c, --config-file <file>', 'specify a custom configuration file (default: app/lib/config.js)', String, path.resolve(root, 'app/lib/config.js'))
+    .option('-c, --config-file <file>', 'specify a custom configuration file (default: app/lib/config.js)')
     // .option('-f, --spec-file <file>', 'the input OpenAPI/Swagger spec file (default: test/fixtures/petstore.json)', String, 'test/fixtures/petstore.json')
     .parse(process.argv);
 
@@ -39,15 +31,7 @@ if (program.args.length < 1) { // && program.rawArgs.length < 1
     program.help();
 }
 
-// Create a new temporary directory, and set some necessary defaults
-program.cacheDir = tmp.dirSync({ unsafeCleanup: true, prefix: 'spectacle-' }).name;
 program.specFile = program.args[0]; // || path.resolve(root, 'test/fixtures/cheese.json');
-
-// Replace some absolute paths
-if (program.specFile && program.specFile.indexOf('test/fixtures') === 0)
-    program.specFile = path.resolve(root, program.specFile);
-if (program.logoFile && program.logoFile.indexOf('test/fixtures') === 0)
-    program.logoFile = path.resolve(root, program.logoFile);
 
 // Run the main app with parsed options
 spectacle(program);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://sourcey.com/spectacle",
   "dependencies": {
+    "bluebird": "^3.4.7",
     "cheerio": "^0.19.0",
     "clarify": "^1.0.5",
     "commander": "*",


### PR DESCRIPTION
Update to be more compatible with programmatic usage.

 - `spectacle()` now returns a promise so you know when it's done.
- Moved option defaults out of bin script to avoid duplication
- Added `silent` option to suppress the console log output