### PR TITLE
Use "example" in "Request example" if defined.

### DIFF
--- a/app/helpers/printSchemaReference.js
+++ b/app/helpers/printSchemaReference.js
@@ -25,3 +25,40 @@ module.exports = function(reference, options) {
   var html = common.printSchema(cloned);
   return new Handlebars.SafeString(html);
 };
+
+
+var Handlebars = require('handlebars');
+var common = require('../lib/common');
+var _ = require('lodash');
+
+module.exports = function(reference, options) {
+  if (!reference) {
+    console.error("Cannot print null reference.");
+    return '';
+  }
+  var model = common.resolveSchemaReference(reference, options.data.root);
+  if (typeof model === 'object' && typeof model.properties === 'object') {
+    if (model['example']) {
+      // Use the supplied example
+      model = model.example;
+      var cloned = _.cloneDeep(model);
+    } else {
+      // Create json object of keys : type info string
+      model = model.properties;
+      var cloned = _.cloneDeep(model);
+      Object.keys(cloned).forEach(function(propName) {
+        var prop = cloned[propName];
+        if (prop.type) {
+          cloned[propName] = prop.type;
+          if (prop.format) {
+            cloned[propName] += ('(' + prop.format + ')');
+          }
+        }
+      })
+    }
+  }
+  if (options.hash.type == 'array')
+    cloned = [cloned];
+  var html = common.printSchema(cloned);
+  return new Handlebars.SafeString(html);
+};

--- a/app/helpers/printSchemaReference.js
+++ b/app/helpers/printSchemaReference.js
@@ -8,44 +8,16 @@ module.exports = function(reference, options) {
     return '';
   }
   var model = common.resolveSchemaReference(reference, options.data.root);
-  if (typeof model === 'object' && typeof model.properties === 'object')
-    model = model.properties;
-  var cloned = _.cloneDeep(model);
-  Object.keys(cloned).forEach(function(propName) {
-    var prop = cloned[propName];
-    if (prop.type) {
-      cloned[propName] = prop.type;
-      if (prop.format) {
-        cloned[propName] += ('(' + prop.format + ')');
-      }
-    }
-  })
-  if (options.hash.type == 'array')
-    cloned = [cloned];
-  var html = common.printSchema(cloned);
-  return new Handlebars.SafeString(html);
-};
-
-
-var Handlebars = require('handlebars');
-var common = require('../lib/common');
-var _ = require('lodash');
-
-module.exports = function(reference, options) {
-  if (!reference) {
-    console.error("Cannot print null reference.");
-    return '';
-  }
-  var model = common.resolveSchemaReference(reference, options.data.root);
   if (typeof model === 'object' && typeof model.properties === 'object') {
-    if (model['example']) {
+    var cloned;
+    if (model.example) {
       // Use the supplied example
       model = model.example;
-      var cloned = _.cloneDeep(model);
+      cloned = _.cloneDeep(model);
     } else {
       // Create json object of keys : type info string
       model = model.properties;
-      var cloned = _.cloneDeep(model);
+      cloned = _.cloneDeep(model);
       Object.keys(cloned).forEach(function(propName) {
         var prop = cloned[propName];
         if (prop.type) {


### PR DESCRIPTION
Wanted to make the "Request Example" section of the paths object respect the "example" key of any references schema object. This is my attempt. It works for us, however its difficult to know all the cases you may be supporting. 