### PR TITLE
Print examples using definition example fields

### DIFF
--- a/app/helpers/printExample.js
+++ b/app/helpers/printExample.js
@@ -1,0 +1,10 @@
+var Handlebars = require('handlebars');
+var common = require('../lib/common');
+
+module.exports = function(value, options) {
+  var cloned = common.formatExample(value, options.data.root);
+  if (options.hash.type == 'array')
+    cloned = [cloned];
+  var html = common.printSchema(cloned);
+  return new Handlebars.SafeString(html)
+};

--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -67,6 +67,47 @@ var common = {
     return cloned;
   },
 
+  formatExample: function(value, root) {
+	if (value.example) {
+	  return value.example;
+	}
+	else if (value.schema && value.schema.$ref)  {
+	  return this.formatExampleProp(value.schema, root);
+	}
+	else if (value.schema && value.schema.items) {
+	  return this.formatExampleProp(value.schema.items.$ref, root);
+	}
+  },
+
+  formatExampleProp: function(ref, root) {
+	var obj = {};
+	var that = this;
+
+	if (ref.$ref) {
+	  ref = this.resolveSchemaReference(ref.$ref, root);
+	  return this.formatExampleProp(ref, root);
+	}
+	else if (ref.type == 'object') {
+	  Object.keys(ref.properties).forEach(function(k) {
+		obj[k] = that.formatExampleProp(ref.properties[k], root);
+	  });
+	}
+	else if (ref.type == 'array' && ref.items) {
+	  obj = [
+		this.formatExampleProp(ref.items, root),
+		this.formatExampleProp(ref.items, root),
+	  ];
+	}
+	else if (ref.example) {
+	  return ref.example;
+	}
+	else {
+	  return ref.type + (ref.format ? ' (' + ref.format + ')' : '');
+	}
+
+	return obj;
+  },
+
   printSchema: function(value) {
     if (!value) {
       return '';

--- a/app/views/partials/swagger/operation.hbs
+++ b/app/views/partials/swagger/operation.hbs
@@ -68,7 +68,7 @@
     <div class="doc-examples">{{#if _show_requst_body_section}}
         <section>
           <h5>Request Example</h5>
-          {{>swagger/print-schema _request_body.schema}}
+          {{>swagger/print-example _request_body}}
         </section>
       {{/if}}</div>
   </div>

--- a/app/views/partials/swagger/print-example.hbs
+++ b/app/views/partials/swagger/print-example.hbs
@@ -1,0 +1,1 @@
+<div class="hljs">{{printExample .}}</div>

--- a/app/views/partials/swagger/responses.hbs
+++ b/app/views/partials/swagger/responses.hbs
@@ -37,18 +37,15 @@
         {{/each}}
       </section>
     </div>
-    
+
     {{! Print examples without whitespace. }}
-    <div class="doc-examples">{{#each responses}}{{#if example}}
+    <div class="doc-examples">
+      {{#each responses}}
         <section>
           <h5>Response Example <span>({{@key}} {{httpResponseCode @key}})</span></h5>
-          {{>swagger/print-schema example}}
+          {{>swagger/print-example .}}
         </section>
-      {{else if schema}}
-        <section>
-          <h5>Response Example <span>({{@key}} {{httpResponseCode @key}})</span></h5>
-          {{>swagger/print-schema schema}}
-        </section>
-      {{/if}}{{/each}}</div>
+      {{/each}}
+    </div>
   </div>
 {{/if}}


### PR DESCRIPTION
Handy dandy examples generated (recursively) from Swagger source file examples.

![bucket-result](https://cloud.githubusercontent.com/assets/332408/23581657/b255f9d4-00cc-11e7-88ae-49ea2702008e.png)

@auscaster 
