### PR TITLE
Render descriptions of security definitions as Markdown

### DIFF
--- a/app/views/partials/swagger/securityDefinitions.hbs
+++ b/app/views/partials/swagger/securityDefinitions.hbs
@@ -25,7 +25,11 @@
                     <div class="prop-title security-definition-property-name">{{@key}}</div>
                   </div>
                   <div class="prop-value security-definition-property-type">
-                    {{this}}
+                    {{#ifeq @key 'description'}}
+                        {{md this}}
+                    {{else}}
+                        {{this}}
+                    {{/ifeq}}
                   </div>
                 </div>
               {{/ifin}}


### PR DESCRIPTION
Noticed this while testing Spectacle.