### PR TITLE
Fix examples with falsy values

### DIFF
--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -94,7 +94,7 @@ var common = {
 
     var that = this;
   	
-    if (ref.example) {
+    if (ref.example !== undefined) {
       return ref.example;
     }
     else if (ref.$ref) {


### PR DESCRIPTION
If you would have an Definition like this:

```
Something:
    type: "object"
    properties:
      value_a
        type: "boolean"
        example: false
      value_b
        type: "integer"
        example: 0
```

The examples would be rendered like this:

```
{
  value_a: "boolean",
  value_a: "integer"
}
```

Instead of:

```
{
  value_a: false,
  value_a: 0
}
```