### PR TITLE
Fix random arrangement of tags in nav

### DIFF
--- a/app/views/partials/layout/nav.hbs
+++ b/app/views/partials/layout/nav.hbs
@@ -14,7 +14,7 @@
 
   {{#if showTagSummary}}
     <h5>Operations</h5>
-    {{#eachSorted tags}}
+    {{#each tags}}
       <section>
         <a href="#tag-{{htmlId name}}">{{name}}</a>
         <ul>
@@ -31,7 +31,7 @@
           {{/each}}
         </ul>
       </section>
-    {{/eachSorted}}
+    {{/each}}
   {{else}}
     <h5>Paths</h5>
     {{#each paths}}

--- a/app/views/partials/swagger/tags.hbs
+++ b/app/views/partials/swagger/tags.hbs
@@ -1,5 +1,5 @@
 {{! Operations sorted by tags }}
-{{#eachSorted tags}}
+{{#each tags}}
     <h1 id="tag-{{htmlId name}}" class="swagger-summary-tag" data-traverse-target="tag-{{htmlId name}}">{{name}}</h1>
     {{#if description}}
       <div class="tag-description doc-row">
@@ -11,4 +11,4 @@
     {{#each operations}}
       {{>swagger/operation . operation=. method=method path=path}}
     {{/each}}
-{{/eachSorted}}
+{{/each}}


### PR DESCRIPTION
Use #each instead of #eachSorted to iterate the list of tag objects. #eachSorted expects an object  and sorts the items randomly on an array.