### PR TITLE
Fix typo/redundancy in usage string

### DIFF
--- a/bin/spectacle.js
+++ b/bin/spectacle.js
@@ -8,7 +8,7 @@ var program = require('commander'),
 //= Process CLI input
 
 program.version(package.version)
-    .usage('spactacle [options] <specfile>')
+    .usage('[options] <specfile>')
     .description(package.description)
     .option('-C, --disable-css', 'omit CSS generation (default: false)')
     .option('-J, --disable-js', 'omit JavaScript generation (default: false)')


### PR DESCRIPTION
The current usage string prints the command name a second time and with a type.
This commit changes the usage from : 
`Usage: spectacle spactacle [options] <specfile>`   
to : 
`Usage: spectacle [options] <specfile>`