### PR TITLE
Feature/add markdown headings to navigation

### DIFF
--- a/app/helpers/mdTraversal.js
+++ b/app/helpers/mdTraversal.js
@@ -1,0 +1,15 @@
+var Handlebars = require('handlebars')
+var common = require('../lib/common')
+
+/**
+ * Render a markdown formatted text as HTML with additional attributes for navigation menu item traversal
+ * @param {string} `value` the markdown-formatted text
+ * @param {boolean} `options.hash.stripParagraph` the marked-md-renderer wraps generated HTML in a <p>-tag by default.
+ *      If this options is set to true, the <p>-tag is stripped.
+ * @returns {Handlebars.SafeString} a Handlebars-SafeString containing the provided
+ *      markdown, rendered as HTML.
+ */
+module.exports = function(value, options) {
+  var html = common.markdownTraversal(value, false)
+  return new Handlebars.SafeString(html)
+};

--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -29,6 +29,24 @@ var common = {
      return html;
   },
 
+  // render heading element with data-traverse-target attribute
+  heading : function (text, level, raw) {
+    return '<h'
+      + level
+      + ' id="'
+      + this.options.headerPrefix
+      + raw.toLowerCase().replace(/[^\w]+/g, '-')
+      + '"'
+      + ' data-traverse-target="'
+      + this.options.headerPrefix
+      + raw.toLowerCase().replace(/[^\w]+/g, '-')
+      + '">'
+      + text
+      + '</h'
+      + level
+      + '>\n';
+  },
+
   highlight: function(code, lang) {
       var highlighted;
       if (lang) {
@@ -213,6 +231,9 @@ highlight.configure({
 // Create a custom renderer for highlight.js compatability
 var renderer = new marked.Renderer()
 renderer.code = common.highlight
+
+// change the default implementation of the heading renderer
+renderer.heading = common.heading
 
 // Configure marked.js
 marked.setOptions({

--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -29,6 +29,29 @@ var common = {
      return html;
   },
 
+  markdownTraversal: function(value, stripParagraph) {
+    if (!value) {
+           return value;
+    }
+
+    var renderer = new marked.Renderer()
+    renderer.code = common.highlight
+
+    // change the default implementation of the heading renderer
+    renderer.heading = common.heading
+
+    var html = marked(value, { renderer: renderer })
+    // We strip the surrounding <p>-tag, if
+    if (stripParagraph) {
+      var $ = cheerio("<root>" + html + "</root>")
+      // Only strip <p>-tags and only if there is just one of them.
+      if ($.children().length === 1 && $.children('p').length === 1) {
+        html = $.children('p').html()
+      }
+    }
+    return html;
+  },
+
   // render heading element with data-traverse-target attribute
   heading : function (text, level, raw) {
     return '<h'
@@ -231,9 +254,6 @@ highlight.configure({
 // Create a custom renderer for highlight.js compatability
 var renderer = new marked.Renderer()
 renderer.code = common.highlight
-
-// change the default implementation of the heading renderer
-renderer.heading = common.heading
 
 // Configure marked.js
 marked.setOptions({

--- a/app/lib/preprocessor.js
+++ b/app/lib/preprocessor.js
@@ -1,5 +1,6 @@
 var path = require('path'),
   _ = require('lodash')
+var marked = require('marked')
 
 var httpMethods = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', '$ref'];
 
@@ -21,6 +22,23 @@ module.exports = function(options, specData) {
   if (options.logoFile) {
     copy.logo = path.basename(options.logoFile)
   }
+
+  // parse description and extract headings
+  var lexer = new marked.Lexer(options);
+  var tokens = lexer.lex(copy.info.description);
+  
+  var headings = tokens.filter(function(token){
+    return token.type == 'heading';
+  })
+  
+  // map heading tokens to introSections structure
+  var introSections = headings.map(function(token){
+    var section = new Object();
+    section.name = token.text;
+    section.id = token.text.toLowerCase().replace(/\s+/g, '-');
+    return section;
+  })
+  copy.introSections = introSections;
 
   // The "body"-parameter in each operation is stored in a
   // separate field "_request_body".

--- a/app/views/partials/layout/nav.hbs
+++ b/app/views/partials/layout/nav.hbs
@@ -7,6 +7,12 @@
   <h5>API Reference</h5>
   <a href="#introduction">Introduction</a>
 
+    <ul>
+    {{#each introSections}}
+        <li><a href="#{{id}}">{{name}}</a></li>
+    {{/each}}
+    </ul>
+
   {{#if securityDefinitions}}
     <!-- <h5>Security</h5> -->
     <a href="#authentication">Authentication</a>

--- a/app/views/partials/swagger/introduction.hbs
+++ b/app/views/partials/swagger/introduction.hbs
@@ -2,7 +2,7 @@
   <h1 class="doc-title">{{info.title}} <span>API Reference</span></h1>
   <div class="doc-row">
     <div class="doc-copy">
-      {{md info.description}}
+      {{mdTraversal info.description}}
     </div>
     <div class="doc-examples">
       <section>


### PR DESCRIPTION
This feature will render Markdown headings in the info.description part of the swagger documentation as additional navigation items.