### PR TITLE
Display ranges as "min ≤ x ≤ max".

### DIFF
--- a/app/helpers/schemaRange.js
+++ b/app/helpers/schemaRange.js
@@ -28,8 +28,14 @@ module.exports = function(range, options) {
         range.maximum)
   } else {
     // if (hasMaxmium && hasMinimum)
-    return util.format("x %s %d | x %s %d",
+    return util.format("%d %s x %s %d",
+        range.minimum,
         range.minimumExclusive ? "<" : "\u2264",
+        range.minimumExclusive ? "<" : "\u2264",
+        range.maximum)
+    // NOTREACHED
+    return util.format("x %s %d | x %s %d",
+        range.minimumExclusive ? ">" : "\u2265",  // <<----- correction here
         range.minimum,
         range.maximumExclusive ? "<" : "\u2264",
         range.maximum)

--- a/app/views/partials/json-schema/datatype.hbs
+++ b/app/views/partials/json-schema/datatype.hbs
@@ -9,6 +9,8 @@
 <span class="json-property-type">
   {{~#if $ref}}
     {{~>json-schema/reference .}}
+  {{~else if items.$ref}}
+    {{~>json-schema/reference .}}
   {{~else}}
     {{~schemaDatatype .}}
   {{~/if}}


### PR DESCRIPTION
This started as a fix for a ≤ facing the wrong way:

![image](https://user-images.githubusercontent.com/1245919/30042604-753259c4-9246-11e7-85df-d8933779db3f.png)

...but the pipe notation meaning "and" didn't really sit quite right with me so I am using this instead:

![image](https://user-images.githubusercontent.com/1245919/30042663-c83d97b4-9246-11e7-8556-6eea42fe8836.png)
