### PR TITLE
Fix #53 - Ensure value of maxLength is displayed

### DIFF
--- a/app/views/partials/json-schema/datatype.hbs
+++ b/app/views/partials/json-schema/datatype.hbs
@@ -54,7 +54,7 @@
 {{else}}
   {{#if maxLength}}
     <span class="json-property-range" title="String length limits">
-      (up to {{maxlength}} chars)
+      (up to {{maxLength}} chars)
     </span>
   {{/if}}
 {{/if}}


### PR DESCRIPTION
This fixes the issue raised in https://github.com/sourcey/spectacle/issues/53.