### PR TITLE
Simplified display of minLength and maxLength of strings when equal

### DIFF
--- a/app/views/partials/json-schema/datatype.hbs
+++ b/app/views/partials/json-schema/datatype.hbs
@@ -46,7 +46,11 @@
 {{#if minLength}}
   <span class="json-property-range" title="String length limits">
     {{#if maxLength}}
-      ({{minLength}} to {{maxLength}} chars)
+      {{#ifeq minLength maxLength}}
+        ({{minLength}} chars)
+      {{else}}
+        ({{minLength}} to {{maxLength}} chars)
+      {{/ifeq}}
     {{else}}
       (at least {{minLength}} chars)
     {{/if}}


### PR DESCRIPTION
This change improves the text when `minLength` and `maxLength` are equal: `(3 chars)` instead of `(3 to 3 chars)`.

This can be helpful for strings which have an exact length (e.g., currency codes and country codes defined in ISO standards).