### PR TITLE
Fix null node references

### DIFF
--- a/app/lib/json-reference.js
+++ b/app/lib/json-reference.js
@@ -37,7 +37,7 @@ function resolveLocal(doc, obj, ref) {
   }
   for(var k in obj) {
     var val = obj[k];
-    if(typeof val !== "object") { continue; }
+    if(typeof val !== "object" || val === null) { continue; }
     if(val.$ref) {
       var $ref = val.$ref;
       if($ref.indexOf("./") === 0 || $ref.indexOf("../") === 0) {

--- a/app/lib/resolve-references.js
+++ b/app/lib/resolve-references.js
@@ -164,7 +164,7 @@ function replaceRefs(cwd, top, obj, context) {
 
   for(var k in obj) {
     var val = obj[k];
-    if(typeof val !== "object") { continue; }
+    if(typeof val !== "object" || val === null) { continue; }
 
     if(val.$ref) {
 

--- a/test/fixtures/NullExample.yml
+++ b/test/fixtures/NullExample.yml
@@ -1,0 +1,14 @@
+type: object
+required:
+  - id
+  - nullable
+properties:
+  id:
+    type: string
+    description: A uuid
+  nullable:
+    type: string
+    description: A field that is nullable
+example:
+  id: b2eb9ac5-5c45-4ec6-af0a-7911cf1759f6
+  nullable: null

--- a/test/test-resolve-references.js
+++ b/test/test-resolve-references.js
@@ -297,6 +297,25 @@ describe("resolve-references.js", function() {
         top.definitions.should.have.property("fixtures/User.yml");
       });
 
+      it("should not error on null ref", function() {
+
+        top = Object.create(minimal);
+        top["x-spec-path"] = cwd + "/test.json";
+        top.paths = { "/": { get: {
+          description: "",
+          responses: { "200": {
+            description: "",
+            schema: {
+              "$ref": "fixtures/NullExample.yml"
+            }
+          }
+          }}}};
+
+        res.replaceRefs(cwd, top, top, "");
+        top.should.have.property("definitions");
+        top.definitions.should.have.property("fixtures/NullExample.yml");
+      });
+
     });
 
   });


### PR DESCRIPTION
This PR fixes a case where `null` is used as a value for an object example. Without the check if a node is null an error is thrown:
```
TypeError: Cannot read property '$ref' of null
    at replaceRefs (/Users/zak/repos/**/node_modules/spectacle-docs/app/lib/resolve-references.js:169:11)

```