### PR TITLE
Fixed typos in cheese store example

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -120,10 +120,10 @@
             <div class="doc-row">
               <div class="doc-copy">
                 <p>Welcome to the sample Cheese Store API reference. This is a live example of how you can use
-                  <a href="http://sourcey.com/spectacle">Spectacle</a> in conjunction with
-                  <a href="http://swagger.io">Swagger</a> to generate beautiful static documentation for your own APIs.</p>
+                  <a href="https://sourcey.com/spectacle">Spectacle</a> in conjunction with
+                  <a href="https://swagger.io">Swagger</a> to generate beautiful static documentation for your own APIs.</p>
                 <p>The Cheese Store API is organized around the
-                  <a href="http://en.wikipedia.org/wiki/Representational_State_Transfer">REST</a> mothodology, and it uses resource-oriented URLs, and common HTTP response codes to indicate API errors. All requests are authenticated using an <code>api-key</code> which can be obtained from your developer dashboard. And now, more cheese...</p>
+                  <a href="https://en.wikipedia.org/wiki/Representational_state_transfer">REST</a> methodology, and it uses resource-oriented URLs, and common HTTP response codes to indicate API errors. All requests are authenticated using an <code>api-key</code> which can be obtained from your developer dashboard. And now, more cheese...</p>
                 <p>Hard cheese gouda say cheese. Ricotta cauliflower cheese cheesecake bocconcini edam bocconcini fromage feta. Who moved my cheese bocconcini cheese and wine cottage cheese cheese on toast who moved my cheese caerphilly stinking bishop. Bocconcini cheesy feet the big cheese macaroni cheese cheesy feet mascarpone.</p>
               </div>
               <div class="doc-examples">
@@ -538,7 +538,7 @@
             <div class="doc-row">
               <div class="doc-copy">
                 <section class="swagger-operation-description">
-                  <p>Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</p>
+                  <p>Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.</p>
                 </section>
               </div>
             </div>
@@ -694,7 +694,7 @@
             <div class="doc-row">
               <div class="doc-copy">
                 <section class="swagger-operation-description">
-                  <p>Return a specific cheese by it&#39;s ID.</p>
+                  <p>Return a specific cheese by its ID.</p>
                 </section>
               </div>
             </div>

--- a/test/fixtures/cheese.json
+++ b/test/fixtures/cheese.json
@@ -1,7 +1,7 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "Welcome to the sample Cheese Store API reference. This is a live example of how you can use [Spectacle](http://sourcey.com/spectacle) in conjunction with [Swagger](http://swagger.io) to generate beautiful static documentation for your own APIs.\n\nThe Cheese Store API is organized around the [REST](http://en.wikipedia.org/wiki/Representational_State_Transfer) mothodology, and it uses resource-oriented URLs, and common HTTP response codes to indicate API errors. All requests are authenticated using an `api-key` which can be obtained from your developer dashboard. And now, more cheese...\n\nHard cheese gouda say cheese. Ricotta cauliflower cheese cheesecake bocconcini edam bocconcini fromage feta. Who moved my cheese bocconcini cheese and wine cottage cheese cheese on toast who moved my cheese caerphilly stinking bishop. Bocconcini cheesy feet the big cheese macaroni cheese cheesy feet mascarpone.\n",
+        "description": "Welcome to the sample Cheese Store API reference. This is a live example of how you can use [Spectacle](https://sourcey.com/spectacle) in conjunction with [Swagger](https://swagger.io) to generate beautiful static documentation for your own APIs.\n\nThe Cheese Store API is organized around the [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) methodology, and it uses resource-oriented URLs, and common HTTP response codes to indicate API errors. All requests are authenticated using an `api-key` which can be obtained from your developer dashboard. And now, more cheese...\n\nHard cheese gouda say cheese. Ricotta cauliflower cheese cheesecake bocconcini edam bocconcini fromage feta. Who moved my cheese bocconcini cheese and wine cottage cheese cheese on toast who moved my cheese caerphilly stinking bishop. Bocconcini cheesy feet the big cheese macaroni cheese cheesy feet mascarpone.\n",
         "version": "1.0.0",
         "title": "Cheese Store",
         "termsOfService": "http://cheesy.sourcey.com/terms",
@@ -148,7 +148,7 @@
                     "Cheese"
                 ],
                 "summary": "Finds cheeses by tags",
-                "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+                "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
                 "operationId": "findCheesesByTags",
                 "produces": [
                     "application/xml",
@@ -201,7 +201,7 @@
                     "Cheese"
                 ],
                 "summary": "Find cheese by ID",
-                "description": "Return a specific cheese by it's ID.",
+                "description": "Return a specific cheese by its ID.",
                 "operationId": "getCheeseById",
                 "produces": [
                     "application/xml",


### PR DESCRIPTION
This change:

- Fixes typos in cheese store example
- Updates a few links to use HTTPS