### PR TITLE
Add null check in replaceRefs

### DIFF
--- a/app/lib/resolve-references.js
+++ b/app/lib/resolve-references.js
@@ -164,7 +164,7 @@ function replaceRefs(cwd, top, obj, context) {
 
   for(var k in obj) {
     var val = obj[k];
-    if(typeof val !== "object") { continue; }
+    if(typeof val !== "object" || !val) { continue; }
 
     if(val.$ref) {
 


### PR DESCRIPTION
`replaceRefs` crashes when a spec has a key with a `null` value
because it does a check `if (typeof val !== "object") { continue; }`
but `typeof(null) === "object"`.

Adding an explicit null check makes `replaceRefs` not crash any more.

Fixes sourcey/spectacle#96.