### PR TITLE
Show enum values in response to fix #69

### DIFF
--- a/app/views/partials/swagger/responses.hbs
+++ b/app/views/partials/swagger/responses.hbs
@@ -34,6 +34,12 @@
               {{md description}}
             </div>
           </div>
+          {{#if schema.type}}
+            <div class="prop-row prop-inner">
+              <div class="prop-name">type</div>
+              <div class="prop-value">{{>json-schema/datatype schema}}</div>
+            </div>
+          {{/if}}
         {{/each}}
       </section>
     </div>

--- a/test/fixtures/issue-69.json
+++ b/test/fixtures/issue-69.json
@@ -1,0 +1,33 @@
+{
+  "swagger": "2.0",
+  "paths": {
+    "/aws/healthcheck": {
+      "get": {
+        "tags": [
+          "Healthcheck"
+        ],
+        "summary": "Returns service status",
+        "description": "Checks if our APIs are online",
+        "operationId": "getStatus",
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "All services online"
+          },
+          "500": {
+            "description": "Something is wrong",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "Db not working",
+                "Redis not working"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change shows enum values in response to fix #69. You can test it with test/fixtures/issue-69.json. 

Here is the screenshot.

<img width="529" alt="issue-69" src="https://user-images.githubusercontent.com/108492/33793341-b8e17800-dcf9-11e7-954e-5a49913dae60.png">



