### PR TITLE
Readable params output, x-spectacle-topics extension

### DIFF
--- a/app/helpers/swaggerCollectionFormat.js
+++ b/app/helpers/swaggerCollectionFormat.js
@@ -1,9 +1,9 @@
 module.exports = function(value, paramName) {
   return {
-    'csv': 'comma separated (`' + paramName + '=aaa,bbb`)',
-    'ssv': 'space separated (`' + paramName + '=aaa bbb`)',
-    'tsv': 'tab separated (`' + paramName + '=aaa\\tbbb`)',
-    'pipes': 'pipe separated (`' + paramName + '=aaa|bbb`)',
-    'multi': 'multiple parameters (`' + paramName + '=aaa&' + paramName + '=bbb`)'
+    'csv': 'Array values passed separated by comma: `?' + paramName + '=aaa,bbb`',
+    'ssv': 'Array values passed separated by space: `?' + paramName + '=aaa bbb`',
+    'tsv': 'Array values passed separated by tab: `?' + paramName + '=aaa\\tbbb`',
+    'pipes': 'Array values passed separated by pipe: `?' + paramName + '=aaa|bbb`',
+    'multi': 'Array values passed as multiple parameters: `?' + paramName + '=aaa&' + paramName + '=bbb`'
   }[value]
 };

--- a/app/stylesheets/_layout.scss
+++ b/app/stylesheets/_layout.scss
@@ -290,6 +290,11 @@ article {
     .prop-title {
       font-weight: bold;
     }
+    
+    .prop-subtitle {
+      font-weight: 400;
+      font-size: 80%;
+    }
 
     .prop-name {
       @extend .columns;

--- a/app/views/partials/layout/content.hbs
+++ b/app/views/partials/layout/content.hbs
@@ -6,6 +6,7 @@
 <article>
   {{>swagger/introduction}}
   {{>swagger/securityDefinitions}}
+  {{>swagger/x-spectacle-topics}}
 
   {{#if showTagSummary}}
     {{>swagger/tags}}
@@ -14,8 +15,6 @@
   {{/if}}
 
   {{>swagger/definitions definitions=definitions}}
-
-  {{>swagger/x-spectacle-articles}}
 
   {{! Powered by link }}
   <div class="doc-row no-margin">

--- a/app/views/partials/layout/content.hbs
+++ b/app/views/partials/layout/content.hbs
@@ -15,6 +15,8 @@
 
   {{>swagger/definitions definitions=definitions}}
 
+  {{>swagger/x-spectacle-articles}}
+
   {{! Powered by link }}
   <div class="doc-row no-margin">
     <div class="doc-copy doc-separator">

--- a/app/views/partials/layout/nav.hbs
+++ b/app/views/partials/layout/nav.hbs
@@ -4,12 +4,17 @@
   @api public
 --}}
 <nav id="nav" role="navigation">
-  <h5>API Reference</h5>
+  <h5>Topics</h5>
   <a href="#introduction">Introduction</a>
 
   {{#if securityDefinitions}}
-    <!-- <h5>Security</h5> -->
     <a href="#authentication">Authentication</a>
+  {{/if}}
+
+  {{#if x-spectacle-topics}}
+    {{#each x-spectacle-topics}}
+      <a href="#topic-{{@key}}">{{name}}</a>
+    {{/each}}
   {{/if}}
 
   {{#if showTagSummary}}
@@ -63,12 +68,6 @@
       {{@key}}
     </a>
   {{/each}}
-  
-  <h5>Articles</h5>
-  {{#if x-spectacle-articles}}
-    {{#each x-spectacle-articles}}
-      <a href="#article-{{@key}}">{{name}}</a>
-    {{/each}}
-  {{/if}}
+
 
 </nav>

--- a/app/views/partials/layout/nav.hbs
+++ b/app/views/partials/layout/nav.hbs
@@ -63,4 +63,12 @@
       {{@key}}
     </a>
   {{/each}}
+  
+  <h5>Articles</h5>
+  {{#if x-spectacle-articles}}
+    {{#each x-spectacle-articles}}
+      <a href="#article-{{@key}}">{{name}}</a>
+    {{/each}}
+  {{/if}}
+
 </nav>

--- a/app/views/partials/swagger/parameters.hbs
+++ b/app/views/partials/swagger/parameters.hbs
@@ -16,6 +16,12 @@
           {{#if required}}
             <span class="json-property-required"></span>
           {{/if}}
+          <div class="prop-subtitle">
+            {{~>json-schema/datatype . ~}}
+            {{#if x-spectacle-default}}
+              / default is {{x-spectacle-default}}
+            {{/if}}
+          </div>
           {{!--
           {{#if schema.$ref}}
             <span class="swagger-global"></span> <span class="json-schema-reference"><a href="{{$ref}}">{{$ref}}</a></span>
@@ -33,16 +39,6 @@
           <div class="prop-value">{{md (swaggerCollectionFormat collectionFormat name) stripParagraph=true}}</div>
         </div>
       {{~/if}}
-      {{! parameter `type` field }}
-      <div class="prop-row prop-inner">
-        <div class="prop-name param-label">type</div>
-        <div class="prop-value">{{~>json-schema/datatype . ~}}</div>
-      </div>
-      {{! parameter `in` field }}
-      <div class="prop-row prop-inner">
-        <div class="prop-name param-label">in</div>
-        <div class="prop-value">{{in}}</div>
-      </div>
     {{/each}}
   </section>
 {{/if}}

--- a/app/views/partials/swagger/parameters.hbs
+++ b/app/views/partials/swagger/parameters.hbs
@@ -17,6 +17,9 @@
             <span class="json-property-required"></span>
           {{/if}}
           <div class="prop-subtitle">
+            in {{in}}
+          </div>
+          <div class="prop-subtitle">
             {{~>json-schema/datatype . ~}}
           </div>
           {{!--
@@ -32,8 +35,7 @@
       {{! parameter `collectionFormat` field }}
       {{~#if collectionFormat ~}}
         <div class="prop-row prop-inner">
-          <div class="prop-name param-label">format</div>
-          <div class="prop-value">{{md (swaggerCollectionFormat collectionFormat name) stripParagraph=true}}</div>
+          {{md (swaggerCollectionFormat collectionFormat name) stripParagraph=true}}
         </div>
       {{~/if}}
     {{/each}}

--- a/app/views/partials/swagger/parameters.hbs
+++ b/app/views/partials/swagger/parameters.hbs
@@ -18,8 +18,8 @@
           {{/if}}
           <div class="prop-subtitle">
             {{~>json-schema/datatype . ~}}
-            {{#if x-spectacle-default}}
-              / default is {{x-spectacle-default}}
+            {{#if default}}
+              / default is {{default}}
             {{/if}}
           </div>
           {{!--

--- a/app/views/partials/swagger/parameters.hbs
+++ b/app/views/partials/swagger/parameters.hbs
@@ -18,9 +18,6 @@
           {{/if}}
           <div class="prop-subtitle">
             {{~>json-schema/datatype . ~}}
-            {{#if default}}
-              / default is {{default}}
-            {{/if}}
           </div>
           {{!--
           {{#if schema.$ref}}

--- a/app/views/partials/swagger/x-spectacle-articles.hbs
+++ b/app/views/partials/swagger/x-spectacle-articles.hbs
@@ -1,0 +1,12 @@
+{{#if x-spectacle-articles}}
+  {{#each x-spectacle-articles}}
+    <h1 id="article-{{@key}}" data-traverse-target="article-{{@key}}">{{name}}</h1>
+    <div class="panel">
+      <div class="doc-row">
+        <div class="doc-copy">
+          {{md description}}
+        </div>
+      </div>
+    </div>
+  {{/each}}
+{{/if}}

--- a/app/views/partials/swagger/x-spectacle-topics.hbs
+++ b/app/views/partials/swagger/x-spectacle-topics.hbs
@@ -1,6 +1,6 @@
-{{#if x-spectacle-articles}}
-  {{#each x-spectacle-articles}}
-    <h1 id="article-{{@key}}" data-traverse-target="article-{{@key}}">{{name}}</h1>
+{{#if x-spectacle-topics}}
+  {{#each x-spectacle-topics}}
+    <h1 id="topic-{{@key}}" data-traverse-target="topic-{{@key}}">{{name}}</h1>
     <div class="panel">
       <div class="doc-row">
         <div class="doc-copy">


### PR DESCRIPTION
I'm working on our API and using spectacle to generate docs.

1. Made tiny updates to UI to make it more readable.
<img width="495" alt="screenshot at jan 12 02-25-12" src="https://user-images.githubusercontent.com/699027/34855866-5bb579b6-f742-11e7-86ec-0b92f44f2c45.png">


2. Added `x-spectacle-topics` extension to schema to allow custom topics in API docs.
```yaml
x-spectacle-topics:
  Versionning:
    name: Versionning
    description: |
      When we make [backwards-incompatible]() changes ...
  Errors:
    name: Errors
    description: |
      API uses conventional HTTP response codes ...
```
Brings topics like in Stripe API docs.
<img width="907" alt="screenshot at jan 12 02-40-45" src="https://user-images.githubusercontent.com/699027/34855887-7f57a394-f742-11e7-912b-3ea2685c0a4f.png">
