### PR TITLE
Option to control rendering flow

### DIFF
--- a/app/views/partials/layout/content.hbs
+++ b/app/views/partials/layout/content.hbs
@@ -4,8 +4,10 @@
 --}}
 
 <article>
-  {{>swagger/introduction}}
-  {{>swagger/securityDefinitions}}
+    {{>swagger/introduction}}
+    {{#unless securityDefinitions.x-spectacle-hide}}
+      {{>swagger/securityDefinitions}}
+    {{/unless}}
   {{>swagger/x-spectacle-topics}}
 
   {{#if showTagSummary}}

--- a/app/views/partials/layout/content.hbs
+++ b/app/views/partials/layout/content.hbs
@@ -4,10 +4,15 @@
 --}}
 
 <article>
+  <h1 class="doc-title">{{info.title}}
+    <span>API Reference</span>
+  </h1>
+   {{#unless info.x-spectacle-hide}}
     {{>swagger/introduction}}
-    {{#unless securityDefinitions.x-spectacle-hide}}
-      {{>swagger/securityDefinitions}}
-    {{/unless}}
+  {{/unless}}
+  {{#unless securityDefinitions.x-spectacle-hide}}
+    {{>swagger/securityDefinitions}}
+  {{/unless}}
   {{>swagger/x-spectacle-topics}}
 
   {{#if showTagSummary}}

--- a/app/views/partials/layout/nav.hbs
+++ b/app/views/partials/layout/nav.hbs
@@ -8,7 +8,9 @@
   <a href="#introduction">Introduction</a>
 
   {{#if securityDefinitions}}
-    <a href="#authentication">Authentication</a>
+      {{#unless securityDefinitions.x-spectacle-hide}}
+        <a href="#authentication">Authentication</a>
+      {{/unless}}
   {{/if}}
 
   {{#if x-spectacle-topics}}

--- a/app/views/partials/layout/nav.hbs
+++ b/app/views/partials/layout/nav.hbs
@@ -5,12 +5,14 @@
 --}}
 <nav id="nav" role="navigation">
   <h5>Topics</h5>
-  <a href="#introduction">Introduction</a>
+  {{#unless info.x-spectacle-hide}}
+    <a href="#introduction">Introduction</a>
+  {{/unless}}
 
   {{#if securityDefinitions}}
-      {{#unless securityDefinitions.x-spectacle-hide}}
-        <a href="#authentication">Authentication</a>
-      {{/unless}}
+   {{#unless securityDefinitions.x-spectacle-hide}}
+     <a href="#authentication">Authentication</a>
+   {{/unless}}
   {{/if}}
 
   {{#if x-spectacle-topics}}

--- a/app/views/partials/layout/nav.hbs
+++ b/app/views/partials/layout/nav.hbs
@@ -13,7 +13,7 @@
 
   {{#if x-spectacle-topics}}
     {{#each x-spectacle-topics}}
-      <a href="#topic-{{@key}}">{{name}}</a>
+      <a href="#topic-{{htmlId @key}}">{{@key}}</a>
     {{/each}}
   {{/if}}
 

--- a/app/views/partials/swagger/introduction.hbs
+++ b/app/views/partials/swagger/introduction.hbs
@@ -1,8 +1,7 @@
 <div id="introduction" data-traverse-target="introduction">
-  <h1 class="doc-title">{{info.title}} <span>API Reference</span></h1>
   <div class="doc-row">
     <div class="doc-copy">
-      {{md info.description}}
+        {{md info.description}}
     </div>
     <div class="doc-examples">
       <section>

--- a/app/views/partials/swagger/x-spectacle-topics.hbs
+++ b/app/views/partials/swagger/x-spectacle-topics.hbs
@@ -1,6 +1,6 @@
 {{#if x-spectacle-topics}}
   {{#each x-spectacle-topics}}
-    <h1 id="topic-{{@key}}" data-traverse-target="topic-{{@key}}">{{name}}</h1>
+    <h1 id="topic-{{htmlId @key}}" data-traverse-target="topic-{{htmlId @key}}">{{@key}}</h1>
     <div class="panel">
       <div class="doc-row">
         <div class="doc-copy">


### PR DESCRIPTION
1. Specify key `x-spectacle-hide: true` in schema to control blocks rendering.

It become possible to disable default rendering of _Introduction_ or _Authorization_ blocks.

```yaml
swagger: '2.0'
info:
  x-spectacle-hide: true
  version: 1.0.0
  title: MyBest REST API
```

```yaml
securityDefinitions:
  x-spectacle-hide: true
  AuthorizationHeader:
    type: apiKey
    name: authorization
    in: header
    example:
      Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
```

2. Extra: href links for topics generated from topic hame with `htmlId` helper.