### PR TITLE
Adding quiet option

### DIFF
--- a/bin/spectacle.js
+++ b/bin/spectacle.js
@@ -21,6 +21,7 @@ program.version(package.version)
     .option('-a, --app-dir <dir>', 'the application source directory (default: app)', String)
     .option('-l, --logo-file <file>', 'specify a custom logo file (default: null)', String, null)
     .option('-c, --config-file <file>', 'specify a custom configuration file (default: app/lib/config.js)')
+    .option('-q, --quiet', 'Silence the output from the generator (default: false)')
     // .option('-f, --spec-file <file>', 'the input OpenAPI/Swagger spec file (default: test/fixtures/petstore.json)', String, 'test/fixtures/petstore.json')
     .parse(process.argv)
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var fs = require('fs'),
 tmp.setGracefulCleanup()
 
 var defaults = {
-    silent: false,
+    quiet: false,
     port: 4400,
     targetDir: path.resolve(process.cwd(), 'public'),
     targetFile: 'index.html',
@@ -59,7 +59,7 @@ module.exports = function (options) {
     //= Setup Grunt to do the heavy lifting
 
     grunt.initConfig(_.merge({ pkg: package }, config))
-    if(opts.silent) {
+    if(opts.quiet) {
         grunt.log.writeln = function() {}
         grunt.log.write = function() {}
         grunt.log.header = function() {}
@@ -128,14 +128,14 @@ module.exports = function (options) {
     var donePromise = new Promise(function(resolve, reject) {
       grunt.task.options({
           error: function(e) {
-              if(!opts.silent) {
+              if(!opts.quiet) {
                   console.warn('Task error:', e)
               }
               // TODO: fail here or push on?
               reject(e)
           },
           done: function() {
-              if(!opts.silent) {
+              if(!opts.quiet) {
                   console.log('All tasks complete')
               }
               resolve()


### PR DESCRIPTION
Passing through the quiet switch to suppress grunt output. Using quiet rather than silent so that we don't clash with the -s server switch.

This doesn't solve the problem of sub tasks being noisy; any ideas on how to suppress that without putting into the background would be appreciated.