### PR TITLE
x-nullable support

### DIFF
--- a/app/views/partials/json-schema/datatype.hbs
+++ b/app/views/partials/json-schema/datatype.hbs
@@ -14,6 +14,9 @@
   {{~else}}
     {{~schemaDatatype .}}
   {{~/if}}
+  {{~#if x-nullable}}
+    | null
+  {{~/if}}
 </span>
 {{~#if format}}
   <span class="json-property-format">({{format}})</span>


### PR DESCRIPTION
We want to support properties in our API endpoints which may be set to the value `null`. We can indicate this in Swagger with the `x-nullable` property, for which there is precedent: https://github.com/OAI/OpenAPI-Specification/issues/229#issuecomment-222942851.

property (with x-nullable) visualization before patch:
 `some_id: integer`

after patch:
`some_id: integer | null`