### PR TITLE
schema syntax errors reporting in development mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,9 +119,12 @@ module.exports = function (options) {
     grunt.registerTask('develop', ['server', 'watch'])
 
     // Reload template data when watch files change
-    grunt.event.on('watch', function(action, filepath) {
-        // if (filepath == config.specFile)
-        grunt.config.set('compile-handlebars.compile.templateData', loadData())
+    grunt.event.on('watch', function() {
+        try {
+            grunt.config.set('compile-handlebars.compile.templateData', loadData())
+        } catch (e) {
+            grunt.fatal(e);
+        }
     })
 
     // Report, etc when all tasks have completed.


### PR DESCRIPTION
resolves #67 

---

before patch:
```
watch task crashes while parsing shema with syntax errors
```

after patch:
```
Fatal error: JS-YAML: bad indentation of a mapping entry in v2.yml at line 497, column 13
            type: integer
                ^

Running "watch" task
Completed in 0.004s at Fri Mar 23 2018 16:57:13 GMT+0300 - Waiting...
```