### PR TITLE
Nest datatype enums under items

### DIFF
--- a/app/views/partials/json-schema/datatype.hbs
+++ b/app/views/partials/json-schema/datatype.hbs
@@ -23,9 +23,9 @@
 {{~/if~}}
 
 {{!-- Enum values --}}
-{{~#if enum}}
+{{~#if items.enum}}
   <span class="json-property-enum" title="Possible values">
-    {{#each enum}}
+    {{#each items.enum}}
       {{! Render enums in the descriminator as links to the appropriate definitions}}
       {{~#if ../discriminator}}
         <span class="json-property-enum-item"><a href="#definition-{{.}}">{{.}}</a></span>


### PR DESCRIPTION
I noticed that my enums weren't showing up when I was parsing some swagger from my grape API, so I did a little research. From what I've read this is where enums should actually be, and it didn't cause any tests to fail. 