### PR TITLE
Allow x-spectacle-topic and security-definition to have examples

### DIFF
--- a/app/stylesheets/_foundation-settings.scss
+++ b/app/stylesheets/_foundation-settings.scss
@@ -78,7 +78,8 @@ $foundation-palette: (
 $light-gray: #e6e6e6;
 $medium-gray: #cacaca;
 $dark-gray: #8a8a8a;
-$black: #23241f; //#0a0a0a;
+$light-black: #353a3d;
+$black: #2d3134; //#0a0a0a;
 $white: #fefefe;
 $body-background: $white;
 $body-font-color: $black;

--- a/app/stylesheets/_layout.scss
+++ b/app/stylesheets/_layout.scss
@@ -21,7 +21,6 @@ button:focus {
   @include small-label($secondary-color);
 }
 
-
 //
 // Topbar layout
 
@@ -102,12 +101,12 @@ button:focus {
 
   section {
     > ul {
-     display: none;
+      display: none;
     }
 
     &.expand {
       > ul {
-       display: block;
+        display: block;
       }
     }
   }
@@ -116,7 +115,6 @@ button:focus {
     opacity: 0.5;
   }
 }
-
 
 //
 // Documentation layout
@@ -233,10 +231,10 @@ article {
     padding-bottom: 0.25rem;
     background-image: url('data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgi…gd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0idXJsKCNncmFkKSIgLz48L3N2Zz4g');
     background-size: 100%;
-    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, rgba(255,255,255,0.4)), color-stop(100%, rgba(255,255,255,0)));
-    background-image: -moz-linear-gradient(top, rgba(255,255,255,0.4), rgba(255,255,255,0));
-    background-image: -webkit-linear-gradient(top, rgba(255,255,255,0.4), rgba(255,255,255,0));
-    background-image: linear-gradient(to bottom, rgba(255,255,255,0.4), rgba(255,255,255,0));
+    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(0%, rgba(255, 255, 255, 0.4)), color-stop(100%, rgba(255, 255, 255, 0)));
+    background-image: -moz-linear-gradient(top, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+    background-image: -webkit-linear-gradient(top, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+    background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
 
   h3 {
@@ -247,16 +245,16 @@ article {
     @extend .doc-content;
   }
 
-  h1+.panel > h2 {
+  h1 + .panel > h2 {
     margin-top: 0;
     border-top: none;
   }
 
-  h1+.tag-description+.panel > h2 {
+  h1 + .tag-description + .panel > h2 {
     margin-top: 2rem;
   }
 
-  h1+.panel h3 {
+  h1 + .panel h3 {
     margin-top: 1rem;
   }
 
@@ -395,7 +393,7 @@ article {
       display: block;
       margin-bottom: 1.5rem;
       padding: 1.5rem;
-      font-family: Consolas,"Liberation Mono",Courier,monospace;
+      font-family: Consolas, "Liberation Mono", Courier, monospace;
       font-weight: inherit;
       color: inherit;
       @include inset-panel();
@@ -404,6 +402,20 @@ article {
       word-break: normal;
     }
 
+    tbody tr:nth-child(even) {
+      border-bottom: 0;
+      background-color: $light-black;
+    }
+
+    tbody, tfoot, thead {
+      color: #FFFFFF;
+      background-color: $black;
+      border: 0px;
+    }
+
+    thead {
+      background-color: $black;
+    }
 
     .swagger-response-headers {
 
@@ -465,7 +477,7 @@ article {
     }
 
     @include breakpoint(large) {
-    // @media screen and (min-width: $large-width) { // large and up
+      // @media screen and (min-width: $large-width) { // large and up
       .operation-tags {
         right: 50%;
       }
@@ -509,14 +521,13 @@ article {
     }
 
     dl dd {
-      font-weight: lighter;
+      font-style: italic;
     }
 
     .json-property-name {
       font-weight: bold;
     }
   }
-
 
   //
   // Code highlighting

--- a/app/views/partials/swagger/securityDefinitions.hbs
+++ b/app/views/partials/swagger/securityDefinitions.hbs
@@ -23,7 +23,7 @@
           {{/if}}
           <section class="swagger-security-definition-properties">
             {{#each this}}
-              {{#ifin @key "['description']"}}
+              {{#ifin @key "['description','x-spectacle-example']"}}
               {{else}}
                 <div class="prop-row security-definition-property">
                   <div class="prop-name">
@@ -44,6 +44,13 @@
             {{/each}}
           </section>
         </div>
+        {{#if x-spectacle-example}}
+          <div class="doc-examples">
+            <section>
+              {{md x-spectacle-example}}
+            </section>
+          </div>
+        {{/if}}
       </div>
     </div>
   {{/each}}

--- a/app/views/partials/swagger/x-spectacle-topics.hbs
+++ b/app/views/partials/swagger/x-spectacle-topics.hbs
@@ -6,6 +6,13 @@
         <div class="doc-copy">
           {{md description}}
         </div>
+        {{#if example}}
+        <div class="doc-examples">
+          <section>
+          {{md example}}
+          </section>
+        </div>
+        {{/if}}
       </div>
     </div>
   {{/each}}


### PR DESCRIPTION
To make `x-spectacle-topic` more powerful so it now supports examples (just add an `example` attribute) which are shown in the right panel. Also allow security-definitions to have examples (with a custom `x-spectacle-example` attribute). 

Some other minor changes:

- Examples now also support tables inside with matching color theme.
- Change from Eternity to Charade as example panel background color for better overall color integrity
- Change property description from `font-weight: lighter` to `font-style: italic` for better readability