### PR TITLE
Change position of type in request parameters

### DIFF
--- a/app/stylesheets/_layout.scss
+++ b/app/stylesheets/_layout.scss
@@ -291,6 +291,10 @@ article {
       font-weight: bold;
     }
 
+    .prop-type {
+      font-weight: 400;
+    }
+
     .prop-subtitle {
       font-weight: 400;
       font-size: 80%;

--- a/app/views/partials/swagger/parameters.hbs
+++ b/app/views/partials/swagger/parameters.hbs
@@ -13,15 +13,12 @@
       {{#schemaReferenceContext $ref}}
         <div class="prop-row prop-group">
           <div class="prop-name">
-            <div class="prop-title">{{name}}</div>
+            <div class="prop-title">{{name}}: <span class="prop-type">{{~>json-schema/datatype . ~}}</span></div>
             {{#if required}}
               <span class="json-property-required"></span>
             {{/if}}
             <div class="prop-subtitle">
               in {{in}}
-            </div>
-            <div class="prop-subtitle">
-              {{~>json-schema/datatype . ~}}
             </div>
             {{!--
             {{#if schema.$ref}}


### PR DESCRIPTION
Change attribute type position in request parameters to match the type style in definitions. Both now show the type directly after the attribute name.