### PR TITLE
Fixed docs from referencing an old file that does not exist in this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Next pass your `swagger.json` document use the CLI to generate your documentatio
 spectacle -d your_swagger_api.json
 
 # Or use the cheese.json example to test it out
-# spectacle -d -l test/fixtures/cheese.png test/fixtures/cheese.json
+# spectacle -d -l test/fixtures/cheese.png test/fixtures/cheese.yml
 ```
 
 Your generated documentation will be located in the `public` directory by default. You can either copy the generated HTML to your web server, or view your docs by pointing your browser to [http://localhost:4400/](http://localhost:4400/).


### PR DESCRIPTION
Changed to reference `cheese.yml`

To prevent the following undesirable outcome for anyone playing along at home
```
spectacle -d -l test/fixtures/cheese.png test/fixtures/cheese.json
fs.js:663
  return binding.open(pathModule.toNamespacedPath(path),
                 ^

Error: ENOENT: no such file or directory, open '/usr/local/lib/node_modules/spectacle-docs/test/fixtures/cheese.json'
  at Object.fs.openSync (fs.js:663:18)
  at Object.fs.readFileSync (fs.js:568:33)
  at Object.fetchReference (/usr/local/lib/node_modules/spectacle-docs/app/lib/resolve-references.js:66:16)
  at loadData (/usr/local/lib/node_modules/spectacle-docs/index.js:55:76)
  at module.exports (/usr/local/lib/node_modules/spectacle-docs/index.js:59:70)
  at Object.<anonymous> (/usr/local/lib/node_modules/spectacle-docs/bin/spectacle.js:39:1)
  at Module._compile (module.js:660:30)
  at Object.Module._extensions..js (module.js:671:10)
  at Module.load (module.js:573:32)
  at tryModuleLoad (module.js:513:12)
  at Function.Module._load (module.js:505:3)
  at Function.Module.runMain (module.js:701:10)
  at startup (bootstrap_node.js:193:16)
  at bootstrap_node.js:617:3
```