### PR TITLE
Fix displaying a response examples

### DIFF
--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -4,6 +4,11 @@ var highlight = require('highlight.js')
 var yaml = require('js-yaml')
 var _ = require('lodash')
 
+const SUPPORTED_MINE_TYPES = [
+  'text/plain',
+  'application/json',
+]
+
 var common = {
 
   /**
@@ -86,13 +91,19 @@ var common = {
       return;
     }
     
-    if (value.example) {
-      return value.example;
+    // Response examples
+    if (value.examples) {
+      for (let mime_type of SUPPORTED_MINE_TYPES) {
+        if (value.examples[mime_type]) {
+          return value.examples[mime_type]
+        }
+      }
     }
-    else if (value.schema) {
+
+    if (value.schema) {
       return this.formatExampleProp(value.schema, root, options)
     }
-    else if (value.type || value.properties || value.allOf)  {
+    if (value.type || value.properties || value.allOf) {
       return this.formatExampleProp(value, root, options)
     }
 

--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -4,7 +4,7 @@ var highlight = require('highlight.js')
 var yaml = require('js-yaml')
 var _ = require('lodash')
 
-const SUPPORTED_MINE_TYPES = [
+const SUPPORTED_MIME_TYPES = [
   'text/plain',
   'application/json',
 ]
@@ -93,7 +93,7 @@ var common = {
     
     // Response examples
     if (value.examples) {
-      for (let mime_type of SUPPORTED_MINE_TYPES) {
+      for (let mime_type of SUPPORTED_MIME_TYPES) {
         if (value.examples[mime_type]) {
           return value.examples[mime_type]
         }

--- a/public/index.html
+++ b/public/index.html
@@ -182,9 +182,9 @@
                       <div class="prop-title security-definition-property-name">scopes</div>
                     </div>
                     <div class="prop-value security-definition-property-type">
-                      <span id="security-definition-scope-write:cheeses">write:cheeses</span>
+                      <span id="security-definition-scope-write-cheeses">write:cheeses</span>
                       <p class="security-definition-scope-description">Modify cheeses in your account</p>
-                      <span id="security-definition-scope-read:cheeses">read:cheeses</span>
+                      <span id="security-definition-scope-read-cheeses">read:cheeses</span>
                       <p class="security-definition-scope-description">Read your cheeses</p>
                     </div>
                   </div>
@@ -403,8 +403,8 @@
                           <a href="#security-definition-cheesy_auth">cheesy_auth</a>
                         </td>
                         <td>
-                          <a href="#security-definition-scope-write:cheeses">write:cheeses</a>,
-                          <a href="#security-definition-scope-read:cheeses">read:cheeses</a>
+                          <a href="#security-definition-scope-write-cheeses">write:cheeses</a>,
+                          <a href="#security-definition-scope-read-cheeses">read:cheeses</a>
                         </td>
                       </tr>
                     </tbody>
@@ -572,8 +572,8 @@
                           <a href="#security-definition-cheesy_auth">cheesy_auth</a>
                         </td>
                         <td>
-                          <a href="#security-definition-scope-write:cheeses">write:cheeses</a>,
-                          <a href="#security-definition-scope-read:cheeses">read:cheeses</a>
+                          <a href="#security-definition-scope-write-cheeses">write:cheeses</a>,
+                          <a href="#security-definition-scope-read-cheeses">read:cheeses</a>
                         </td>
                       </tr>
                     </tbody>
@@ -745,8 +745,8 @@
                           <a href="#security-definition-cheesy_auth">cheesy_auth</a>
                         </td>
                         <td>
-                          <a href="#security-definition-scope-write:cheeses">write:cheeses</a>,
-                          <a href="#security-definition-scope-read:cheeses">read:cheeses</a>
+                          <a href="#security-definition-scope-write-cheeses">write:cheeses</a>,
+                          <a href="#security-definition-scope-read-cheeses">read:cheeses</a>
                         </td>
                       </tr>
                     </tbody>
@@ -1047,8 +1047,8 @@
                           <a href="#security-definition-cheesy_auth">cheesy_auth</a>
                         </td>
                         <td>
-                          <a href="#security-definition-scope-write:cheeses">write:cheeses</a>,
-                          <a href="#security-definition-scope-read:cheeses">read:cheeses</a>
+                          <a href="#security-definition-scope-write-cheeses">write:cheeses</a>,
+                          <a href="#security-definition-scope-read-cheeses">read:cheeses</a>
                         </td>
                       </tr>
                     </tbody>
@@ -1171,8 +1171,8 @@
                           <a href="#security-definition-cheesy_auth">cheesy_auth</a>
                         </td>
                         <td>
-                          <a href="#security-definition-scope-write:cheeses">write:cheeses</a>,
-                          <a href="#security-definition-scope-read:cheeses">read:cheeses</a>
+                          <a href="#security-definition-scope-write-cheeses">write:cheeses</a>,
+                          <a href="#security-definition-scope-read-cheeses">read:cheeses</a>
                         </td>
                       </tr>
                     </tbody>
@@ -1344,8 +1344,8 @@
                           <a href="#security-definition-cheesy_auth">cheesy_auth</a>
                         </td>
                         <td>
-                          <a href="#security-definition-scope-write:cheeses">write:cheeses</a>,
-                          <a href="#security-definition-scope-read:cheeses">read:cheeses</a>
+                          <a href="#security-definition-scope-write-cheeses">write:cheeses</a>,
+                          <a href="#security-definition-scope-read-cheeses">read:cheeses</a>
                         </td>
                       </tr>
                     </tbody>
@@ -1495,8 +1495,8 @@
                           <a href="#security-definition-cheesy_auth">cheesy_auth</a>
                         </td>
                         <td>
-                          <a href="#security-definition-scope-write:cheeses">write:cheeses</a>,
-                          <a href="#security-definition-scope-read:cheeses">read:cheeses</a>
+                          <a href="#security-definition-scope-write-cheeses">write:cheeses</a>,
+                          <a href="#security-definition-scope-read-cheeses">read:cheeses</a>
                         </td>
                       </tr>
                     </tbody>


### PR DESCRIPTION
This PR fixes issue #181 
According to the OpenAPI v2.0 Specifications*, response examples have to be defined
in a 'examples' field, not 'example'. Furthermore, an example must be an Example Object**.

\* https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#response-object
** https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#example-object