### PR TITLE
fix example rendering

### DIFF
--- a/app/lib/common.js
+++ b/app/lib/common.js
@@ -118,19 +118,10 @@ var common = {
       return;
     }
 
-    // Keep depth-based circular reference detection around to
-    // avoid errors in case '$ref's aren't being used
-    // /usr/local/bin/node bin/spectacle -d test/fixtures/billing.yaml
-    if (!options.depth) {
-      options.depth = 0;
-    }
-    options.depth++;
-    if (options.depth > 100) {
-      return;
-    }
-
+    options = _.cloneDeep(options);
     // Watch for circular references with '$ref' and use that instead of
     // trying to make a recursive example
+    // /usr/local/bin/node bin/spectacle -d test/fixtures/billing.yaml
     if (!options.refsSeen) {
       options.refsSeen = [];
     }


### PR DESCRIPTION
This fixes an issue we were seeing where large schemas would have missing properties in the examples.

Previously, because `options` are shared between recursive calls, only a maximum of 100 properties would be rendered in total. (It would be less if `$ref` are used, because the indirection counts towards the limit).

Since the fix in #190 prevents circular examples from ending in an infinite loop, I removed the "depth" check. I've tested it with the referenced billing.yaml example and it works fine. If you prefer I can leave it in, though since it now truly checks for depth, 100 would be a pretty high limit, so I don't think it adds anything.

Also if the same `$ref` is used multiple times in the same schema, even if not recursive, it would previously only render the first occurrence.

Here's an example of billing.yaml before and after:
<img width="1003" alt="Bildschirmfoto 2020-01-30 um 09 12 11" src="https://user-images.githubusercontent.com/7610492/73431556-fe33d880-4340-11ea-8637-bea55cf00023.png">

Notice that `id` was missing in a lot of places because it is a `$ref` and is used on the top level already, so it was not render it in nested objects.

Recursive examples like this still work: (`Service` object which contains a nested `Service` object + `ServicePeriod` which has nested `ServicePeriod`)
<img width="488" alt="Bildschirmfoto 2020-01-30 um 09 13 04" src="https://user-images.githubusercontent.com/7610492/73431870-ae094600-4341-11ea-8801-fe197cea0c0d.png">
