### PR TITLE
Fix predentation task can't handle empty lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = function (options) {
                 // Determine the level of indentation
                 lines.forEach(function(line) {
                     if (line[0] === '<') return;
-                    var wsp = line.search(/\S/)
+                    var wsp = line.search(/\S|$/)
                     level = (level === null || (wsp < line.length && wsp < level)) ? wsp : level;
                 })
 


### PR DESCRIPTION
If the predentation task faces an empty line the indentation level getting set to -1 and this messes up the corresponding code blocks indentation in the final result