### PR TITLE
Add portable SKILL.md

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: sourcey-operator-bringup-workflow
+description: Agent-readable workflow guidance for sourcey/sourcey.
+---
+
+# Sourcey Operator Bringup Workflow
+
+This is a portable skill document for agents working in `sourcey/sourcey`.
+
+## Evidence Sources
+
+- `.github/workflows/ci.yml`
+- `README.md`
+- `package.json`
+
+## Workflow
+
+Use this skill when working on the `operator-bringup` workflow. Inspect the evidence sources before editing, preserve existing validation commands, and report any skipped checks explicitly.
+
+## Safe Operating Rules
+
+- Prefer repo-documented commands over invented commands.
+- Do not claim support that the repo docs or CI do not validate.
+- Keep mutation boundaries explicit and ask for approval before publishing external changes.
+
+## Optional Compatible Tooling Note
+
+This file is a portable `SKILL.md`. Agents and tools that understand `SKILL.md` can use it as repo workflow context. runx can optionally pair it with a registry binding for execution, verification, and receipts, but this repo does not require runx to use the file.
+


### PR DESCRIPTION
## What changed

This PR adds `SKILL.md`, a portable agent-readable workflow document for `sourcey/sourcey`.

## Why this belongs in the repo

Agents already inspect README files, package scripts, CI config, Docker docs, and release scripts when working in a repo. A dedicated `SKILL.md` gives them a stable workflow contract so they can make safer, more repo-specific decisions without changing the runtime, CI, release process, or package layout.

For this repo, the skill focuses on build, validation, packaging, release, Docker demo, and operator bring-up paths.

The goal is not to add another docs page for humans to maintain separately. The goal is to make the repo's existing operational knowledge legible to agents in the same place maintainers already review project conventions.

## Why `SKILL.md`

`SKILL.md` is becoming a recognizable portable format for agent capabilities and workflow context:

- The Agent Skills specification defines `SKILL.md` as the required metadata-plus-instructions file for a skill package: https://agentskills.io/specification
- The Agent Skills overview frames skills as portable, version-controlled packages for procedural knowledge and repeatable workflows: https://agentskills.io/
- Anthropic's public skills repository uses self-contained folders with `SKILL.md` files and links to the Agent Skills specification: https://github.com/anthropics/skills
- Claude's Skills docs describe the progressive-disclosure model: agents load lightweight metadata first, then read the full `SKILL.md` only when the task matches: https://claude.com/docs/skills/overview

That pattern fits this repo well: `icey-server` has concrete build, browser-smoke, Docker, release, and package-manager workflows that agents should follow precisely instead of rediscovering from scattered files each time.

## Evidence used

- `.github/workflows/ci.yml`
- `README.md`
- `package.json`

## Portability

The file is plain markdown. It is useful as project documentation and as agent context. Tools that understand `SKILL.md`, including runx, can optionally execute or verify it, but this PR does not add a runx dependency.

## What this does not do

- It does not change build behavior.
- It does not add generated code.
- It does not add a service dependency.
- It does not add a runx config file.
- It does not publish anything to a registry.

## Maintainer review checklist

- Does the file describe the repo's real workflows accurately?
- Are any commands stale, too broad, or missing important prerequisites?
- Is the optional compatibility note acceptable, or should it be removed?
- Should any workflow guidance be narrower before merge?

<!-- aster:generated-pr-policy lane=skill-upstream merge=human_review draft_only=true -->
## Generated PR Policy

- Generated by lane: `skill-upstream`
- Publication mode: `draft-only` until a human intentionally promotes the PR
- Merge policy: `human-reviewed` only; no autonomous merge is allowed
- Correction policy: use the `rollback` workflow or a corrective PR/comment when this output is wrong
- Receipts: inspect the linked workflow artifacts before review or merge

## Change Surface Policy

- Repo scope: `external` report-only
- Policy status: `report_only`
- Surfaces touched: `other`